### PR TITLE
Add Travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+before_script:
+  # theses are dependencies of pandoc & pdfinfo
+  - sudo apt-get install texlive texlive-xetex lmodern pandoc fonts-lato poppler-utils -y
+script:
+  - bundle exec jekyll build
+  - pandoc pages/cgu.md -o _site/assets/cgu.pdf --latex-engine=xelatex
+  # check pdf has at least one page
+  - pdfinfo _site/assets/cgu.pdf | grep -w 'Pages:\s*[1-9].*'


### PR DESCRIPTION
Ajout de Travis:
`apt-get` pour installer toutes les dépendances de : 
- `pandoc` (génération du PDF des CGU)
- `pdfinfo` (pour vérifier que le PDF est généré sans erreur - 0 pages par exemple)

3 étapes : 
- build jekyll
- génération du PDF
- vérification de la validitié du PDF