### PR TITLE
Corrige le lien vers signup

### DIFF
--- a/_layouts/usecases.html
+++ b/_layouts/usecases.html
@@ -12,7 +12,7 @@ layout: default
     <aside class="tpl-documentation__sidebar">
       <nav class="tpl-documentation__links">
         {% include toc.html html=content %}
-        <a class="tpl-button tpl-button--gradient" href="https://signup.api.gouv.fr/">Demander un accès</a>
+        <a class="tpl-button tpl-button--gradient" href="https://signup.api.gouv.fr/api-entreprise">Demander un accès</a>
       </nav>
     </aside>
     <div class="tpl-documentation__content">


### PR DESCRIPTION
Le lien ne renvoyait pas sur la page dédiée à API Entreprise