### PR TITLE
Le endpoint d'AGEFIPH accepte un siret et non un siren

### DIFF
--- a/_catalogue/conformité-emploi-des-travailleurs-handicapés.md
+++ b/_catalogue/conformité-emploi-des-travailleurs-handicapés.md
@@ -17,8 +17,8 @@ services:
   service1:
     request:
       id:
-        label: SirenDeL’Entreprise
-        description: Le numéro de SIREN de l'entreprise.
+        label: SiretDeL’Etablissement
+        description: Le numéro de SIRET de l'établissement.
       parameters:
         param1:
           label: token


### PR DESCRIPTION
La documentation indique qu'il faut passer en paramètre le SIREN, hors il s'avère que c'est le SIRET qui est censé être utilisé.