### PR TITLE
Documentation APIs: disponibilités et privileges de token

### DIFF
--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -38,6 +38,7 @@ panels:
 
       Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel2:
+  panel3:
     title: Connaître la disponibilité des API en temps réel 📊
     id: api-disponibilites
     content: >-
@@ -176,7 +177,7 @@ panels:
 
 
       Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
-  panel3:
+  panel4:
     title: Interpréter les codes HTTP 🚦
     id: http-codes
     content: >-
@@ -250,7 +251,7 @@ panels:
 
 
       En cas d’erreur, le JSON vous détaille la raison de l’erreur, le champ concerné se nomme `“errors”`. Lorsqu’un endpoint retourne des données agrégées de plusieurs fournisseurs, le JSON renvoyé contient un champ `“gateway error”`. Sa valeur vaut `“true”` lorsqu'une erreur survient auprès d'au moins un fournisseur.
-  panel4:
+  panel5:
     title: Renouveler un token en fin de vie 💫
     id: renouvellement-token
     content: >-
@@ -330,7 +331,7 @@ panels:
 
 
       </details>
-  panel5:
+  panel6:
     title: Réagir en cas d’incidents fournisseurs de données 🚧
     id: incident-fournisseurs
     content: >-
@@ -341,7 +342,7 @@ panels:
       1. Dans une telle situation, **la première chose à faire est de consulter la [page incident](https://dashboard.entreprise.api.gouv.fr/incidents)** et de vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une indisponibilité pour maintenance.\
          Vous pouvez **également consulter la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time)** et ainsi vérifier si l'endpoint ne fonctionnant pas est indiqué comme DOWN dans l'interface. API Entreprise a effectivement mis en place un système de test permettant de vérifier l'état de disponibilité de tous les endpoints.
       2. Si l'incident n'est pas répertorié, deux options se présentent : l'erreur provient de votre côté, ou bien elle n'a pas encore été identifiée par API Entreprise. Après avoir pris soin de regarder qu'il ne s'agit pas de la première option, vous pouvez nous contacter sur [support@entreprise.api.gouv.fr](mailto:support@entreprise.api.gouv.fr).
-  panel6:
+  panel7:
     title: Réagir en cas d’indisponibilité globale 🚧
     id: indisponibilite-globale
     content: >-
@@ -355,7 +356,7 @@ panels:
 
 
       🚧 Ce contenu est en cours de construction et sera bientôt disponible. 🚧
-  panel7:
+  panel8:
     title: Élargir le périmètre des données demandées 🧩
     id: elargissement-perimetre
     content: >-
@@ -369,7 +370,7 @@ panels:
 
 
       Si l'habilitation vous est donnée, API Entreprise vous fournira un nouveau jeton contenant le nouveau périmètre des endpoints accessibles.
-  panel8:
+  panel9:
     title: S'adapter aux évolutions et montées de versions 🏗
     id: evolutions
     content: |-

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -5,6 +5,175 @@ identifier: quotidien
 id: quotidien
 panels:
   panel1:
+    title: Connaître les droits liés à un token 🛂
+    id: api-privileges
+    content: >-
+      Si vous souhaitez connaître la liste des APIs auxquelles **vous avez le
+      droit** avec votre token vous pouvez le vérifier avec cette API.
+
+
+      Si vous gérer les tokens pour vos clients vous pouvez aussi utiliser cette API pour vérfier les droits associés à leurs tokens.
+
+
+      **Exemple**
+
+
+      {:.example}
+
+      GET https://entreprise.api.gouv.fr/v2/privileges?token=TOKEN
+
+
+      ```json
+
+      {
+        "privileges": [
+          "attestations_agefiph",
+          [...]
+          "actes_bilans_inpi"
+        ]
+      }
+
+      ```
+
+
+      [Un Swagger est disponible](https://api.gouv.fr/documentation/api-entreprise)
+  panel2:
+    title: Connaître la disponibilité des API en temps réel 📊
+    id: api-disponibilites
+    content: >-
+      Si vous souhaitez connaître la disponibilité de nos APIs en temps réel
+      nous mettons à votre disposition les données.
+
+
+      Exemple
+
+
+      {:.example}
+
+      GET https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=6M&endpoint=api/v3/entreprises_restored
+
+
+      ```json
+
+      {
+        "endpoint": "api/v3/entreprises_restored",
+        "days_availability": {
+          "2020-04-13": {
+            "total": 12615,
+            "404": 9,
+            "502": 0,
+            "503": 0,
+            "504": 0
+          },
+          "2020-04-14": {
+            "total": 44677,
+            "404": 25,
+            "502": 0,
+            "503": 16,
+            "504": 0
+          }
+        },
+        "total_availability": 99.96,
+        "last_week_availability": 100.0
+      }
+
+      ```
+
+
+      **PARAMÈTRES**
+
+
+      Cette API possède deux paramètres, _period_ et _endpoint_ voici comment les utiliser.
+
+
+      **Pour le paramètre "period"**
+
+
+      {:.tpl-table}
+
+      |Exemples de _period_|signification|
+
+      |---|---|
+
+      |1y | depuis un an |
+
+      |2M | depuis 2 mois |
+
+      |3w | depuis 3 semaines |
+
+      |4d | depuis 4 jours |
+
+      |5h | depuis 5 heures |
+
+      |6m | depuis 6 minutes |
+
+      |7s | depuis 7 secondes |
+
+
+      **Pour le paramètre "endpoint"**
+
+
+      {:.tpl-table}
+
+      |Liste exhaustive des valeurs de _endpoint_|API correspondante|
+
+      |---|---|
+
+      |api/v3/entreprises_restored|[Entreprises](https://entreprise.api.gouv.fr/catalogue/#entreprises)|
+
+      |api/v3/etablissements_restored|[Établissements](https://entreprise.api.gouv.fr/catalogue/#etablissements)|
+
+      |api/v2/extraits_rcs_infogreffe|[Extrait RCS](https://entreprise.api.gouv.fr/catalogue/#extraits_rcs_infogreffe)|
+
+      |api/v2/associations|[Informations déclaratives d’une association](https://entreprise.api.gouv.fr/catalogue/#associations)|
+
+      |api/v2/documents_associations|[Divers documents d'une association](https://entreprise.api.gouv.fr/catalogue/#documents_associations)|
+
+      |api/v2/documents_inpi|[Actes INPI](https://entreprise.api.gouv.fr/catalogue/#actes_inpi)|
+
+      |api/v2/conventions_collectives|[Conventions collectives ](https://entreprise.api.gouv.fr/catalogue/#conventions_collectives)|
+
+      |api/v2/exercices|[Chiffre d'affaires](https://entreprise.api.gouv.fr/catalogue/#exercices)|
+
+      |api/v2/documents_inpi|[Bilans annuels INPI](https://entreprise.api.gouv.fr/catalogue/#bilans_inpi)|
+
+      |api/v2/bilans_entreprises_bdf|[3 derniers bilans annuels](https://entreprise.api.gouv.fr/catalogue/#bilans_entreprises_bdf)|
+
+      |api/v2/liasses_fiscales_dgfip|[Déclarations de résultat](https://entreprise.api.gouv.fr/catalogue/#liasses_fiscales_dgfip)|
+
+      |api/v2/attestations_fiscales_dgfip|[Attestation fiscale](https://entreprise.api.gouv.fr/catalogue/#attestations_fiscales_dgfip)|
+
+      |api/v2/attestations_sociales_acoss|[Attestation de vigilance](https://entreprise.api.gouv.fr/catalogue/#attestations_sociales_acoss)|
+
+      |api/v2/attestations_agefiph|[Conformité emploi des travailleurs handicapés](https://entreprise.api.gouv.fr/catalogue/#attestations_agefiph)|
+
+      |api/v2/cotisations_msa|[Cotisations de sécurité sociale agricole](https://entreprise.api.gouv.fr/catalogue/#cotisations_msa)|
+
+      |api/v2/attestations_cotisation_retraite_probtp|[Attestation de cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
+
+      |api/v2/eligibilites_cotisation_retraite_probtp|[Éligibilité au cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
+
+      |api/v2/cartes_professionnelles_fntp|[Carte professionnelle travaux publics](https://entreprise.api.gouv.fr/catalogue/#cartes_professionnelles_fntp)|
+
+      |api/v2/certificats_cnetp|[Cotisations congés payés & chômage intempéries](https://entreprise.api.gouv.fr/catalogue/#certificats_cnetp)|
+
+      |api/v2/certificats_rge_ademe|[Certification RGE](https://entreprise.api.gouv.fr/catalogue/#certificats_rge_ademe)|
+
+      |api/v2/certificats_qualibat|[Certificat de qualification bâtiment](https://entreprise.api.gouv.fr/catalogue/#certificats_qualibat)|
+
+      |api/v2/certificats_opqibi|[Certification de qualification d'ingénierie](https://entreprise.api.gouv.fr/catalogue/#certificats_opqibi)|
+
+      |api/v2/extraits_courts_inpi|[Brevets modèles et marques déposés](https://entreprise.api.gouv.fr/catalogue/#extraits_courts_inpi)|
+
+      |api/v2/effectifs_mensuels_etablissement_acoss_covid|Effectifs mensuels par établissement (aides COVID-19) - documentation à venir|
+
+      |api/v2/effectifs_mensuels_entreprise_acoss_covid|Effectifs mensuels par entreprise (aides COVID-19) - documentation à venir|
+
+      |api/v2/effectifs_annuels_entreprise_acoss_covid|Effectifs annuels par entreprise (aides COVID-19) - documentation à venir|
+
+
+      [Un Swagger est disponible](https://api.gouv.fr/documentation/api-entreprise)
+  panel3:
     title: Interpréter les codes HTTP 🚦
     id: http-codes
     content: >-
@@ -78,16 +247,16 @@ panels:
 
 
       En cas d’erreur, le JSON vous détaille la raison de l’erreur, le champ concerné se nomme `“errors”`. Lorsqu’un endpoint retourne des données agrégées de plusieurs fournisseurs, le JSON renvoyé contient un champ `“gateway error”`. Sa valeur vaut `“true”` lorsqu'une erreur survient auprès d'au moins un fournisseur.
-  panel2:
+  panel4:
     title: Renouveler un token en fin de vie 💫
     id: renouvellement-token
     content: >-
       Pour des raisons de sécurité, tous les jetons émis sont valables pour
       **une durée de 18 mois**. Au delà de ce délai, ils ne fonctionnent plus,
-      et votre accès à l'API Entreprise est donc totalement arrêté. 
+      et votre accès à l'API Entreprise est donc totalement arrêté.
 
 
-      En réalité, cette situation n'est pas censée arriver car API Entreprise a mis en place une procédure simple de renouvellement de token. En voici les étapes : 
+      En réalité, cette situation n'est pas censée arriver car API Entreprise a mis en place une procédure simple de renouvellement de token. En voici les étapes :
 
 
       <details class="fold">
@@ -116,7 +285,7 @@ panels:
 
       Un renouvellement de jeton est en pratique une nouvelle demande d'accès.
 
-      Il existe deux possibilités de renouvellement de votre token selon que vous ayez fait votre dernière demande avant septembre 2019 ou après. Nous avons en effet transformé l'outil pour effectuer une demande d'accès à l'API Entreprise. Hier, il s'agissait de demarches-simplifiees.fr ; aujourd'hui, il s'agit d'api.gouv.fr. 
+      Il existe deux possibilités de renouvellement de votre token selon que vous ayez fait votre dernière demande avant septembre 2019 ou après. Nous avons en effet transformé l'outil pour effectuer une demande d'accès à l'API Entreprise. Hier, il s'agissait de demarches-simplifiees.fr ; aujourd'hui, il s'agit d'api.gouv.fr.
 
 
       **Cas n°1 : Votre dernière demande remonte avant septembre 2019** et a été réalisée au travers de demarches-simplifiees.fr
@@ -158,7 +327,7 @@ panels:
 
 
       </details>
-  panel3:
+  panel5:
     title: Réagir en cas d’incidents fournisseurs de données 🚧
     id: incident-fournisseurs
     content: >-
@@ -169,7 +338,7 @@ panels:
       1. Dans une telle situation, **la première chose à faire est de consulter la [page incident](https://dashboard.entreprise.api.gouv.fr/incidents)** et de vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une indisponibilité pour maintenance.\
          Vous pouvez **également consulter la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time)** et ainsi vérifier si l'endpoint ne fonctionnant pas est indiqué comme DOWN dans l'interface. API Entreprise a effectivement mis en place un système de test permettant de vérifier l'état de disponibilité de tous les endpoints.
       2. Si l'incident n'est pas répertorié, deux options se présentent : l'erreur provient de votre côté, ou bien elle n'a pas encore été identifiée par API Entreprise. Après avoir pris soin de regarder qu'il ne s'agit pas de la première option, vous pouvez nous contacter sur [support@entreprise.api.gouv.fr](mailto:support@entreprise.api.gouv.fr).
-  panel4:
+  panel6:
     title: Réagir en cas d’indisponibilité globale 🚧
     id: indisponibilite-globale
     content: >-
@@ -183,7 +352,7 @@ panels:
 
 
       🚧 Ce contenu est en cours de construction et sera bientôt disponible. 🚧
-  panel5:
+  panel7:
     title: Élargir le périmètre des données demandées 🧩
     id: elargissement-perimetre
     content: >-
@@ -193,11 +362,11 @@ panels:
       **[Il vous faut refaire une demande d'habilitation](#demande-habilitation).**
 
 
-      Pour toute nouvelle demande, il vous faudra **justifier le cadre légal**. 
+      Pour toute nouvelle demande, il vous faudra **justifier le cadre légal**.
 
 
       Si l'habilitation vous est donnée, API Entreprise vous fournira un nouveau jeton contenant le nouveau périmètre des endpoints accessibles.
-  panel6:
+  panel8:
     title: S'adapter aux évolutions et montées de versions 🏗
     id: evolutions
     content: |-

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -45,6 +45,9 @@ panels:
       nous mettons à votre disposition les données.
 
 
+      **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.
+
+
       Exemple
 
 

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -36,7 +36,7 @@ panels:
       ```
 
 
-      [Un Swagger est disponible](https://api.gouv.fr/documentation/api-entreprise)
+      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel2:
     title: Connaître la disponibilité des API en temps réel 📊
     id: api-disponibilites
@@ -175,7 +175,7 @@ panels:
       |api/v2/effectifs_annuels_entreprise_acoss_covid|Effectifs annuels par entreprise (aides COVID-19) - documentation à venir|
 
 
-      [Un Swagger est disponible](https://api.gouv.fr/documentation/api-entreprise)
+      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel3:
     title: Interpréter les codes HTTP 🚦
     id: http-codes

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -48,7 +48,7 @@ panels:
       La réponse JSON renvoie la liste des endpoints autorisés. Retrouvez-les dans le [catalogue des données](../catalogue/).
 
 
-      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à l'[environnement de production documenté (*swagger*) disponible sur api.gouv.fr](https://api.gouv.fr/documentation/api-entreprise){:target="_blank"}.
   panel2:
     title: Connaître la disponibilité des API en temps réel ✅
     id: api-current-status
@@ -99,7 +99,7 @@ panels:
       ```
 
 
-      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à l'[environnement de production documenté (*swagger*) disponible sur api.gouv.fr](https://api.gouv.fr/documentation/api-entreprise){:target="_blank"}.
   panel3:
     title: Connaître l'historique de disponibilité des API 📊
     id: api-disponibilites
@@ -247,7 +247,7 @@ panels:
       |`api/v2/effectifs_annuels_entreprise_acoss_covid`|Effectifs annuels par entreprise (aides COVID-19) - documentation à venir|
 
 
-      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à l'[environnement de production documenté (*swagger*) disponible sur api.gouv.fr](https://api.gouv.fr/documentation/api-entreprise){:target="_blank"}.
   panel4:
     title: Interpréter les codes HTTP 🚦
     id: http-codes

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -38,12 +38,58 @@ panels:
 
       Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel2:
+    title: Connaître la disponibilité des API en temps réel ✅
+    id: api-current-status
+    content: >-
+      Pour connaître la disponibilité des données de API Entreprise en temps
+      réel.
+
+
+      **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.
+
+
+      Exemple
+
+
+      {:.example}
+
+      GET https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status
+
+
+      ```json
+
+      {
+        "results": [
+          {
+            "uname": "apie_2_etablissements",
+            "name": "Etablissements",
+            "provider": "insee",
+            "api_version": 2,
+            "code": 200,
+            "timestamp": "2020-10-14T14:36:33.640Z"
+          },
+          {
+            "uname": "apie_2_certificats_qualibat",
+            "name": "Certificats Qualibat",
+            "provider": "qualibat",
+            "api_version": 2,
+            "code": 503,
+            "timestamp": "2020-10-14T14:38:02.736Z"
+          },
+          [...]
+        ]
+      }
+
+      ```
+
+
+      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel3:
-    title: Connaître la disponibilité des API en temps réel 📊
+    title: Connaître l'historique de disponibilité des API 📊
     id: api-disponibilites
     content: >-
-      Pour connaître la disponibilité de API Entreprise en temps réel les
-      données, ainsi que le taux d'erreurs constatées.
+      Pour connaître l'historique de disponibilité des données de API Entreprise
+      ainsi que le taux d'erreurs constatées.
 
 
       **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -11,13 +11,19 @@ panels:
       Pour connaître **la liste des APIs auxquelles vous avez le droit** avec
       votre jeton d'accès, vous pouvez le vérifier avec l'API `/privileges`.
 
+
+
       Si vous gérez les tokens pour vos clients, vous pouvez aussi utiliser cette API pour vérifier les droits associés à leurs tokens.
 
 
       ###### La requête HTTP :
 
 
-      `https://entreprise.api.gouv.fr/v2/privileges?token=LeTokenATester`
+      ```
+
+      https://entreprise.api.gouv.fr/v2/privileges?token=LeTokenATester
+
+      ```
 
 
       Le paramètre d'appel à renseigner est le token dont vous souhaitez connaître les droits.
@@ -26,13 +32,17 @@ panels:
       ###### Exemple de réponse :
 
 
-      `{
+      ```json
+
+      {
         "privileges": [
           "attestations_agefiph",
           [...]
           "actes_bilans_inpi"
         ]
-      }`
+      }
+
+      ```
 
 
       La réponse JSON renvoie la liste des endpoints autorisés. Retrouvez-les dans le [catalogue des données](../catalogue/).
@@ -52,13 +62,19 @@ panels:
       ###### La requête HTTP :
 
 
-      `https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status`
+      ```
+
+      https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status
+
+      ```
 
 
       ###### Exemple de réponse :
 
 
-      `{
+      ```json
+
+      {
         "results": [
           {
             "uname": "apie_2_etablissements",
@@ -78,7 +94,9 @@ panels:
           },
           [...]
         ]
-      }`
+      }
+
+      ```
 
 
       ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
@@ -96,7 +114,12 @@ panels:
       ###### La requête HTTP :
 
 
-      `https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=ParamètreDeLaPeriode&endpoint=ParamètreDeL'Endpoint`
+      ````
+
+      https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=ParamètreDeLaPeriode&endpoint=ParamètreDuEndpoint
+
+      ```
+
 
       Pour appeler l'API concernant l'endpoint et la période voulue, référez-vous à la suite de cet article ⤵️
 
@@ -104,7 +127,9 @@ panels:
       ###### Exemple de réponse :
 
 
-      `{
+      ```json
+
+      {
         "endpoint": "api/v3/entreprises_restored",
         "days_availability": {
           "2020-04-13": {
@@ -124,13 +149,15 @@ panels:
         },
         "total_availability": 99.96,
         "last_week_availability": 100.0
-      }`
+      }
+
+      ```
 
 
       ###### **Nomenclature des paramètres de la requête HTTP :**
 
 
-      Cette API possède deux paramètres, `period` et `endpoint`, voici leur nomenclature : 
+      Cette API possède deux paramètres, `period` et `endpoint`, voici leur nomenclature :
 
 
       {:.tpl-table}

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -64,7 +64,7 @@ panels:
 
       ```
 
-      https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status
+      https://entreprise.api.gouv.fr/watchdoge/dashboard/current_status
 
       ```
 
@@ -116,7 +116,7 @@ panels:
 
       ````
 
-      https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=ParamètreDeLaPeriode&endpoint=ParamètreDuEndpoint
+      https://entreprise.api.gouv.fr/watchdoge/stats/provider_availabilities?period=ParamètreDeLaPeriode&endpoint=ParamètreDuEndpoint
 
       ```
 

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -156,7 +156,7 @@ panels:
       {:.tpl-table}
 
 
-      À partir de la nomenclature, `Y`(année), `M`(mois), `W`(semaine), `D`(jour), `m`(minute), `s`(seconde), vous pouvez obtenir l'historique de disponibilité de la période que vous souhaitez. Nous conservons cet historique pendant XX années.
+      À partir de la nomenclature, `Y`(année), `M`(mois), `W`(semaine), `D`(jour), `m`(minute), `s`(seconde), vous pouvez obtenir l'historique de disponibilité de la période que vous souhaitez.
 
 
 

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -12,7 +12,7 @@ panels:
       droit** avec votre token vous pouvez le vérifier avec cette API.
 
 
-      Si vous gérer les tokens pour vos clients vous pouvez aussi utiliser cette API pour vérfier les droits associés à leurs tokens.
+      Si vous gérer les tokens pour vos clients vous pouvez aussi utiliser cette API pour vérifier les droits associés à leurs tokens.
 
 
       **Exemple**
@@ -41,8 +41,8 @@ panels:
     title: Connaître la disponibilité des API en temps réel 📊
     id: api-disponibilites
     content: >-
-      Si vous souhaitez connaître la disponibilité de nos APIs en temps réel
-      nous mettons à votre disposition les données.
+      Pour connaître la disponibilité de API Entreprise en temps réel les
+      données, ainsi que le taux d'erreurs constatées.
 
 
       **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -8,57 +8,57 @@ panels:
     title: Connaître les droits liés à un token 🛂
     id: api-privileges
     content: >-
-      Si vous souhaitez connaître la liste des APIs auxquelles **vous avez le
-      droit** avec votre token vous pouvez le vérifier avec cette API.
+      Pour connaître **la liste des APIs auxquelles vous avez le droit** avec
+      votre jeton d'accès, vous pouvez le vérifier avec l'API `/privileges`.
+
+      Si vous gérez les tokens pour vos clients, vous pouvez aussi utiliser cette API pour vérifier les droits associés à leurs tokens.
 
 
-      Si vous gérer les tokens pour vos clients vous pouvez aussi utiliser cette API pour vérifier les droits associés à leurs tokens.
+      ###### La requête HTTP :
 
 
-      **Exemple**
+      `https://entreprise.api.gouv.fr/v2/privileges?token=LeTokenATester`
 
 
-      {:.example}
-
-      GET https://entreprise.api.gouv.fr/v2/privileges?token=TOKEN
+      Le paramètre d'appel à renseigner est le token dont vous souhaitez connaître les droits.
 
 
-      ```json
+      ###### Exemple de réponse :
 
-      {
+
+      `{
         "privileges": [
           "attestations_agefiph",
           [...]
           "actes_bilans_inpi"
         ]
-      }
-
-      ```
+      }`
 
 
-      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      La réponse JSON renvoie la liste des endpoints autorisés. Retrouvez-les dans le [catalogue des données](../catalogue/).
+
+
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel2:
     title: Connaître la disponibilité des API en temps réel ✅
     id: api-current-status
     content: >-
-      Pour connaître la disponibilité des données de API Entreprise en temps
-      réel.
+      Pour connaître la disponibilité de tous les endpoints en temps réel, vous
+      pouvez utiliser l'API `/current_status`. Cette **API est ouverte et ne
+      nécessite pas de token**, attention à tout de même respecter les [limites
+      de volumétrie](./#configuration) habituelle.
 
 
-      **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.
+      ###### La requête HTTP :
 
 
-      Exemple
+      `https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status`
 
 
-      {:.example}
-
-      GET https://dashboard.entreprise.api.gouv.fr/api/watchdoge/dashboard/current_status
+      ###### Exemple de réponse :
 
 
-      ```json
-
-      {
+      `{
         "results": [
           {
             "uname": "apie_2_etablissements",
@@ -78,34 +78,33 @@ panels:
           },
           [...]
         ]
-      }
-
-      ```
+      }`
 
 
-      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel3:
     title: Connaître l'historique de disponibilité des API 📊
     id: api-disponibilites
     content: >-
       Pour connaître l'historique de disponibilité des données de API Entreprise
-      ainsi que le taux d'erreurs constatées.
+      ainsi que le taux d'erreurs constatées, vous pouvez utiliser l'API
+      `/provider_availabilities`. **Cette API est ouverte et ne nécessite pas de
+      token**, attention à tout de même respecter les [limites de
+      volumétrie](./#configuration) habituelle.
 
 
-      **Cette API est ouverte et ne nécessite pas de token**, attention à tout de même respecter les [limites de volumétrie](./#configuration) habituelle.
+      ###### La requête HTTP :
 
 
-      Exemple
+      `https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=ParamètreDeLaPeriode&endpoint=ParamètreDeL'Endpoint`
+
+      Pour appeler l'API concernant l'endpoint et la période voulue, référez-vous à la suite de cet article ⤵️
 
 
-      {:.example}
-
-      GET https://dashboard.entreprise.api.gouv.fr/api/watchdoge/stats/provider_availabilities?period=6M&endpoint=api/v3/entreprises_restored
+      ###### Exemple de réponse :
 
 
-      ```json
-
-      {
+      `{
         "endpoint": "api/v3/entreprises_restored",
         "days_availability": {
           "2020-04-13": {
@@ -125,104 +124,103 @@ panels:
         },
         "total_availability": 99.96,
         "last_week_availability": 100.0
-      }
-
-      ```
+      }`
 
 
-      **PARAMÈTRES**
+      ###### **Nomenclature des paramètres de la requête HTTP :**
 
 
-      Cette API possède deux paramètres, _period_ et _endpoint_ voici comment les utiliser.
-
-
-      **Pour le paramètre "period"**
+      Cette API possède deux paramètres, `period` et `endpoint`, voici leur nomenclature : 
 
 
       {:.tpl-table}
 
-      |Exemples de _period_|signification|
+      |Liste indicative de *period*|Période correspondante|
 
       |---|---|
 
-      |1y | depuis un an |
+      |`1y` | depuis un an |
 
-      |2M | depuis 2 mois |
+      |`2M` | depuis 2 mois |
 
-      |3w | depuis 3 semaines |
+      |`3w` | depuis 3 semaines |
 
-      |4d | depuis 4 jours |
+      |`4d` | depuis 4 jours |
 
-      |5h | depuis 5 heures |
+      |`5h` | depuis 5 heures |
 
-      |6m | depuis 6 minutes |
+      |`6m` | depuis 6 minutes |
 
-      |7s | depuis 7 secondes |
+      |`7s` | depuis 7 secondes |
+
+      {:.tpl-table}
 
 
-      **Pour le paramètre "endpoint"**
+      À partir de la nomenclature, `Y`(année), `M`(mois), `W`(semaine), `D`(jour), `m`(minute), `s`(seconde), vous pouvez obtenir l'historique de disponibilité de la période que vous souhaitez. Nous conservons cet historique pendant XX années.
+
+
 
 
       {:.tpl-table}
 
-      |Liste exhaustive des valeurs de _endpoint_|API correspondante|
+      |Liste exhaustive des *endpoint*|API correspondante|
 
       |---|---|
 
-      |api/v3/entreprises_restored|[Entreprises](https://entreprise.api.gouv.fr/catalogue/#entreprises)|
+      |`api/v3/entreprises_restored`|[Entreprises](https://entreprise.api.gouv.fr/catalogue/#entreprises)|
 
-      |api/v3/etablissements_restored|[Établissements](https://entreprise.api.gouv.fr/catalogue/#etablissements)|
+      |`api/v3/etablissements_restored`|[Établissements](https://entreprise.api.gouv.fr/catalogue/#etablissements)|
 
-      |api/v2/extraits_rcs_infogreffe|[Extrait RCS](https://entreprise.api.gouv.fr/catalogue/#extraits_rcs_infogreffe)|
+      |`api/v2/extraits_rcs_infogreffe`|[Extrait RCS](https://entreprise.api.gouv.fr/catalogue/#extraits_rcs_infogreffe)|
 
-      |api/v2/associations|[Informations déclaratives d’une association](https://entreprise.api.gouv.fr/catalogue/#associations)|
+      |`api/v2/associations`|[Informations déclaratives d’une association](https://entreprise.api.gouv.fr/catalogue/#associations)|
 
-      |api/v2/documents_associations|[Divers documents d'une association](https://entreprise.api.gouv.fr/catalogue/#documents_associations)|
+      |`api/v2/documents_associations`|[Divers documents d'une association](https://entreprise.api.gouv.fr/catalogue/#documents_associations)|
 
-      |api/v2/documents_inpi|[Actes INPI](https://entreprise.api.gouv.fr/catalogue/#actes_inpi)|
+      |`api/v2/documents_inpi`|[Actes INPI](https://entreprise.api.gouv.fr/catalogue/#actes_inpi)|
 
-      |api/v2/conventions_collectives|[Conventions collectives ](https://entreprise.api.gouv.fr/catalogue/#conventions_collectives)|
+      |`api/v2/conventions_collectives`|[Conventions collectives ](https://entreprise.api.gouv.fr/catalogue/#conventions_collectives)|
 
-      |api/v2/exercices|[Chiffre d'affaires](https://entreprise.api.gouv.fr/catalogue/#exercices)|
+      |`api/v2/exercices`|[Chiffre d'affaires](https://entreprise.api.gouv.fr/catalogue/#exercices)|
 
-      |api/v2/documents_inpi|[Bilans annuels INPI](https://entreprise.api.gouv.fr/catalogue/#bilans_inpi)|
+      |`api/v2/documents_inpi`|[Bilans annuels INPI](https://entreprise.api.gouv.fr/catalogue/#bilans_inpi)|
 
-      |api/v2/bilans_entreprises_bdf|[3 derniers bilans annuels](https://entreprise.api.gouv.fr/catalogue/#bilans_entreprises_bdf)|
+      |`api/v2/bilans_entreprises_bdf`|[3 derniers bilans annuels](https://entreprise.api.gouv.fr/catalogue/#bilans_entreprises_bdf)|
 
-      |api/v2/liasses_fiscales_dgfip|[Déclarations de résultat](https://entreprise.api.gouv.fr/catalogue/#liasses_fiscales_dgfip)|
+      |`api/v2/liasses_fiscales_dgfip`|[Déclarations de résultat](https://entreprise.api.gouv.fr/catalogue/#liasses_fiscales_dgfip)|
 
-      |api/v2/attestations_fiscales_dgfip|[Attestation fiscale](https://entreprise.api.gouv.fr/catalogue/#attestations_fiscales_dgfip)|
+      |`api/v2/attestations_fiscales_dgfip`|[Attestation fiscale](https://entreprise.api.gouv.fr/catalogue/#attestations_fiscales_dgfip)|
 
-      |api/v2/attestations_sociales_acoss|[Attestation de vigilance](https://entreprise.api.gouv.fr/catalogue/#attestations_sociales_acoss)|
+      |`api/v2/attestations_sociales_acoss`|[Attestation de vigilance](https://entreprise.api.gouv.fr/catalogue/#attestations_sociales_acoss)|
 
-      |api/v2/attestations_agefiph|[Conformité emploi des travailleurs handicapés](https://entreprise.api.gouv.fr/catalogue/#attestations_agefiph)|
+      |`api/v2/attestations_agefiph`|[Conformité emploi des travailleurs handicapés](https://entreprise.api.gouv.fr/catalogue/#attestations_agefiph)|
 
-      |api/v2/cotisations_msa|[Cotisations de sécurité sociale agricole](https://entreprise.api.gouv.fr/catalogue/#cotisations_msa)|
+      |`api/v2/cotisations_msa`|[Cotisations de sécurité sociale agricole](https://entreprise.api.gouv.fr/catalogue/#cotisations_msa)|
 
-      |api/v2/attestations_cotisation_retraite_probtp|[Attestation de cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
+      |`api/v2/attestations_cotisation_retraite_probtp`|[Attestation de cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
 
-      |api/v2/eligibilites_cotisation_retraite_probtp|[Éligibilité au cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
+      |`api/v2/eligibilites_cotisation_retraite_probtp`|[Éligibilité au cotisations retraite du bâtiment](https://entreprise.api.gouv.fr/catalogue/#cotisation_retraite_probtp)|
 
-      |api/v2/cartes_professionnelles_fntp|[Carte professionnelle travaux publics](https://entreprise.api.gouv.fr/catalogue/#cartes_professionnelles_fntp)|
+      |`api/v2/cartes_professionnelles_fntp`|[Carte professionnelle travaux publics](https://entreprise.api.gouv.fr/catalogue/#cartes_professionnelles_fntp)|
 
-      |api/v2/certificats_cnetp|[Cotisations congés payés & chômage intempéries](https://entreprise.api.gouv.fr/catalogue/#certificats_cnetp)|
+      |`api/v2/certificats_cnetp`|[Cotisations congés payés & chômage intempéries](https://entreprise.api.gouv.fr/catalogue/#certificats_cnetp)|
 
-      |api/v2/certificats_rge_ademe|[Certification RGE](https://entreprise.api.gouv.fr/catalogue/#certificats_rge_ademe)|
+      |`api/v2/certificats_rge_ademe`|[Certification RGE](https://entreprise.api.gouv.fr/catalogue/#certificats_rge_ademe)|
 
-      |api/v2/certificats_qualibat|[Certificat de qualification bâtiment](https://entreprise.api.gouv.fr/catalogue/#certificats_qualibat)|
+      |`api/v2/certificats_qualibat`|[Certificat de qualification bâtiment](https://entreprise.api.gouv.fr/catalogue/#certificats_qualibat)|
 
-      |api/v2/certificats_opqibi|[Certification de qualification d'ingénierie](https://entreprise.api.gouv.fr/catalogue/#certificats_opqibi)|
+      |`api/v2/certificats_opqibi`|[Certification de qualification d'ingénierie](https://entreprise.api.gouv.fr/catalogue/#certificats_opqibi)|
 
-      |api/v2/extraits_courts_inpi|[Brevets modèles et marques déposés](https://entreprise.api.gouv.fr/catalogue/#extraits_courts_inpi)|
+      |`api/v2/extraits_courts_inpi`|[Brevets modèles et marques déposés](https://entreprise.api.gouv.fr/catalogue/#extraits_courts_inpi)|
 
-      |api/v2/effectifs_mensuels_etablissement_acoss_covid|Effectifs mensuels par établissement (aides COVID-19) - documentation à venir|
+      |`api/v2/effectifs_mensuels_etablissement_acoss_covid`|Effectifs mensuels par établissement (aides COVID-19) - documentation à venir|
 
-      |api/v2/effectifs_mensuels_entreprise_acoss_covid|Effectifs mensuels par entreprise (aides COVID-19) - documentation à venir|
+      |`api/v2/effectifs_mensuels_entreprise_acoss_covid`|Effectifs mensuels par entreprise (aides COVID-19) - documentation à venir|
 
-      |api/v2/effectifs_annuels_entreprise_acoss_covid|Effectifs annuels par entreprise (aides COVID-19) - documentation à venir|
+      |`api/v2/effectifs_annuels_entreprise_acoss_covid`|Effectifs annuels par entreprise (aides COVID-19) - documentation à venir|
 
 
-      Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
+      ℹ️ Pour plus d'informations, vous pouvez vous référer à la [documentation technique](https://api.gouv.fr/documentation/api-entreprise).
   panel4:
     title: Interpréter les codes HTTP 🚦
     id: http-codes

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -41,7 +41,7 @@ collections:
       - label: 'Titre'
         name: 'title'
         required: true
-        widget: 'text'
+        widget: 'string'
       - label: 'ID'
         name: 'id'
         required: true
@@ -328,7 +328,7 @@ collections:
                     - label: 'Paramètre'
                       name: 'label'
                       required: false
-                      default: 'token' 
+                      default: 'token'
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
@@ -342,12 +342,12 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'context' 
+                      default: 'context'
                       required: false
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
-                      default: 'CadreDeLaRequête' 
+                      default: 'CadreDeLaRequête'
                       required: false
                       widget: 'string'
                 - label: 'Paramètre obligatoire 3'
@@ -357,7 +357,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'recipient' 
+                      default: 'recipient'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -372,7 +372,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'object' 
+                      default: 'object'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -472,16 +472,16 @@ collections:
                 required: false
                 widget: 'select'
                 multiple: false
-                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']          
+                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']
               - label: 'Timeout'
                 name: 'timeout'
                 widget: 'select'
                 multiple: false
-                options: ['5 secondes', '12 secondes'] 
+                options: ['5 secondes', '12 secondes']
               - label: 'Description'
                 name: 'description'
                 required: false
-                widget: 'markdown'  
+                widget: 'markdown'
               - label: 'Questions/réponses'
                 name: 'questions'
                 widget: 'object'
@@ -525,7 +525,7 @@ collections:
                       - label: 'Réponse'
                         name: 'answer'
                         required: false
-                        widget: 'markdown'  
+                        widget: 'markdown'
               - label: 'Réponse type'
                 name: 'sample'
                 required: false
@@ -623,7 +623,7 @@ collections:
                     - label: 'Paramètre'
                       name: 'label'
                       required: false
-                      default: 'token' 
+                      default: 'token'
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
@@ -637,12 +637,12 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'context' 
+                      default: 'context'
                       required: false
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
-                      default: 'CadreDeLaRequête' 
+                      default: 'CadreDeLaRequête'
                       required: false
                       widget: 'string'
                 - label: 'Paramètre obligatoire 3'
@@ -652,7 +652,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'recipient' 
+                      default: 'recipient'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -667,7 +667,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'object' 
+                      default: 'object'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -767,17 +767,17 @@ collections:
                 required: false
                 widget: 'select'
                 multiple: false
-                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']          
+                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']
               - label: 'Timeout'
                 name: 'timeout'
                 widget: 'select'
                 multiple: false
                 required: false
-                options: ['5 secondes', '12 secondes'] 
+                options: ['5 secondes', '12 secondes']
               - label: 'Description'
                 name: 'description'
                 required: false
-                widget: 'markdown'  
+                widget: 'markdown'
               - label: 'Questions/réponses'
                 name: 'questions'
                 widget: 'object'
@@ -821,7 +821,7 @@ collections:
                       - label: 'Réponse'
                         name: 'answer'
                         required: false
-                        widget: 'markdown'  
+                        widget: 'markdown'
               - label: 'Réponse type'
                 name: 'sample'
                 required: false
@@ -919,7 +919,7 @@ collections:
                     - label: 'Paramètre'
                       name: 'label'
                       required: false
-                      default: 'token' 
+                      default: 'token'
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
@@ -933,12 +933,12 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'context' 
+                      default: 'context'
                       required: false
                       widget: 'string'
                     - label: 'Description'
                       name: 'description'
-                      default: 'CadreDeLaRequête' 
+                      default: 'CadreDeLaRequête'
                       required: false
                       widget: 'string'
                 - label: 'Paramètre obligatoire 3'
@@ -948,7 +948,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'recipient' 
+                      default: 'recipient'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -963,7 +963,7 @@ collections:
                   fields:
                     - label: 'Paramètre'
                       name: 'label'
-                      default: 'object' 
+                      default: 'object'
                       required: false
                       widget: 'string'
                     - label: 'Description'
@@ -1063,17 +1063,17 @@ collections:
                 required: false
                 widget: 'select'
                 multiple: false
-                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']          
+                options: ['Donnée structurée JSON', 'Document PDF', 'Archive ZIP contenant PDF ou JPEG', 'Archive ZIP contenant PDF et XML']
               - label: 'Timeout'
                 name: 'timeout'
                 widget: 'select'
                 multiple: false
                 required: false
-                options: ['5 secondes', '12 secondes'] 
+                options: ['5 secondes', '12 secondes']
               - label: 'Description'
                 name: 'description'
                 required: false
-                widget: 'markdown'  
+                widget: 'markdown'
               - label: 'Questions/réponses'
                 name: 'questions'
                 widget: 'object'
@@ -1117,7 +1117,7 @@ collections:
                       - label: 'Réponse'
                         name: 'answer'
                         required: false
-                        widget: 'markdown'  
+                        widget: 'markdown'
               - label: 'Réponse type'
                 name: 'sample'
                 required: false


### PR DESCRIPTION
#### Que fait cette PR ?
Ajout dans la "Documentation Générale" d'une documentation pour les APIs:
- `/privileges`
- `/provider_availabilities`
- `/current_status`

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?
Il a été demandé lors du dernier OpenLab que les FS/FD puisse avoir accès à la disponibilité par API.

Pour l'API `/privileges` cette demande vient de Slack

Voilà les screenshots, WDYT ? :
![Screenshot_2020-10-14 API Entreprise](https://user-images.githubusercontent.com/5159985/96005229-ed7eb080-0e44-11eb-8db3-9ca9124289bb.png)
![Screenshot_2020-10-14 API Entreprise(1)](https://user-images.githubusercontent.com/5159985/96005239-ef487400-0e44-11eb-8e7e-454c6856b2ed.png)
![Screenshot_2020-10-14 API Entreprise(2)](https://user-images.githubusercontent.com/5159985/96005246-f1123780-0e44-11eb-8fc6-1c271bb844f9.png)
![Screenshot_2020-10-14 API Entreprise(3)](https://user-images.githubusercontent.com/5159985/96005255-f2dbfb00-0e44-11eb-8a52-ed8a53dfaa78.png)
