### PR TITLE
Ajout de notre politique de certificats SSL

### DIFF
--- a/_documentation/démarrer-avec-api-entreprise.md
+++ b/_documentation/démarrer-avec-api-entreprise.md
@@ -301,6 +301,18 @@ panels:
       Pour mettre à disposition les données API Entreprise depuis un navigateur, **il vous faut mettre en place un système de proxy** pour ne pas appeler directement nos APIs.
 
 
+      #### Certificats SSL et Autorités de certification
+
+
+      API Entreprise utilise [DHIMYOTIS](https://www.dhimyotis.com/) comme organisme de délivrance de ses certificats SSL principaux ainsi que [Let's Encrypt](https://letsencrypt.org/) pour certains services secondaires.
+
+
+      Il est conseillé d'ajouter ces Autorités de Certifications (AC) à votre base de confiance si vous en avez une. Une solution idéale est d'utiliser un paquet d'autorités mises à jour automatiquement ([Mozilla par exemple](https://wiki.mozilla.org/CA/Included_Certificates))
+
+
+      API Entreprise utilise des certificats multi-domaines ; c'est à dire avec un "nom courant" (_common name - CN_) et plusieurs "noms alternatifs du sujet" (_subject alternatives names - SAN_), soyez certains que vos outils fonctionnent correctement avec.
+
+
       #### Construire en compatibilité ascendante
 
 

--- a/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
+++ b/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
@@ -56,7 +56,7 @@ panels:
       |**Des paramètres de traçabilité**|`&context=CadreDeLaRequête`<br> `&recipientBénéficiareDeL'Appel=`<br> `&object=RaisonDeL'AppelOuIdentifiant`<br> `?user_id=IdentifiantDeL'UtilisateurPhysique`<br> et autres selon les endpoints ...|
 
 
-      **Tous ces éléments mis bout à bout constituent une requête HTTP qui appelle l'API :** 
+      **Tous ces éléments mis bout à bout constituent une requête HTTP qui appelle l'API :**
 
 
       ```
@@ -185,8 +185,8 @@ panels:
     title: Les fondamentaux à mettre en place avec l'équipe technique 🧰
     id: fondamentaux
     content: >
-      
-      Vous travaillez avec la DSI de votre administration ou avec un éditeur de logiciel, voici la liste des fondamentaux que votre équipe technique doit être en mesure de mettre en place pour un bon fonctionnement de l'API Entreprise : 
+
+      Vous travaillez avec la DSI de votre administration ou avec un éditeur de logiciel, voici la liste des fondamentaux que votre équipe technique doit être en mesure de mettre en place pour un bon fonctionnement de l'API Entreprise :
 
 
       ✅ Pouvoir prendre en charge la mise à jour des protocoles de sécurité HTTPS ;
@@ -202,6 +202,9 @@ panels:
 
 
       ✅ Anticiper les coûts de maintenance qui s'ajouteront aux coûts de mise en place.
+
+
+      ✅ S'assurer que nos Autorités de Certification (AC) pour les certificats SSL sont autorisées par vos systèmes. Consulter la _fin_ de la rubrique [configurer le logiciel métier](#configuration).
   panel4:
     title: Prévoir les incidents et la résilience de mon service 🧑‍🚒
     id: incidents


### PR DESCRIPTION
#### Que fait cette PR ?
Ajour d'une section concernant notre politique de gestion des certificats SSL et des CA

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?
Suite à un changement d'autorité de certification pour notre certificat SSL de production ; certain usagers n'avaient pas autorisé Let's Encrypt parmis les CA autorisés.

On documente donc notre politique

#### Screenshot

![image](https://user-images.githubusercontent.com/5159985/98570499-30a13780-22bc-11eb-8212-34bffbb487ae.png)
et
![image](https://user-images.githubusercontent.com/5159985/98570536-3a2a9f80-22bc-11eb-932c-3fece2c8bc26.png)