### PR TITLE
Nouveaux cas d'usages v2

### DIFF
--- a/_includes/usecases.html
+++ b/_includes/usecases.html
@@ -25,3 +25,32 @@
     <p>Récupérez les justificatifs administratifs de vos utilisateurs demandant des aides publiques.</p>
   </div>
 </a>
+{% unless include.homepage %}
+<a href="{{ site.baseurl }}{% link _use_cases/preremplissage_public.md %}" class="tpl-card tpl-shadow">
+  <div class="tpl-card__header">
+    <h3 class="tpl-card__title"><strong>Pré-remplir</strong> un formulaire en <strong>accès libre</strong> et le personnaliser</h3>
+  </div>
+  <div class="tpl-card__content">
+    <img class="card__icon" src="{{ site.baseurl }}{% link assets/images/usecases/preremplissage-public.svg %}" alt="" />
+    <p>Facilitez la saisie de vos formulaires avec les données publiques API Entreprise.</p>
+  </div>
+</a>
+<a href="{{ site.baseurl }}{% link _use_cases/preremplissage_securise.md %}" class="tpl-card tpl-shadow">
+  <div class="tpl-card__header">
+    <h3 class="tpl-card__title"><strong>Pré-remplir</strong> un formulaire avec <strong>accès sécurisé</strong> et le personnaliser</h3>
+  </div>
+  <div class="tpl-card__content">
+    <img class="card__icon" src="{{ site.baseurl }}{% link assets/images/usecases/preremplissage-securise.svg %}" alt="" />
+    <p>Facilitez la saisie de vos formulaires sous authentification avec les données API Entreprise.</p>
+  </div>
+</a>
+<a href="{{ site.baseurl }}{% link _use_cases/editeurs.md %}" class="tpl-card tpl-shadow">
+  <div class="tpl-card__header">
+    <h3 class="tpl-card__title">Intégrer l'API Entreprise<br>en tant qu'<strong>éditeur</strong></h3>
+  </div>
+  <div class="tpl-card__content">
+    <img class="card__icon" src="{{ site.baseurl }}{% link assets/images/usecases/editeurs.svg %}" alt="" />
+    <p>Branchez-vous à l'API Entreprise pour améliorer vos services aux entreprises et associations</p>
+  </div>
+</a>
+{% endunless %}

--- a/_includes/usecases.html
+++ b/_includes/usecases.html
@@ -7,7 +7,7 @@
     <p>Vérifiez l'éligibilité des demandes des TPE et associations à l'aide complémentaire dans le cadre de la crise sanitaire.</p>
   </div>
 </a>
-<a href="{{ site.baseurl }}{% link _use_cases/marches_publics.md %}" class="tpl-card tpl-shadow">
+<a href="{{ site.baseurl }}{% link _use_cases/marches_publics2.md %}" class="tpl-card tpl-shadow">
   <div class="tpl-card__header">
     <h3 class="tpl-card__title">Faciliter la candidature aux <strong>marchés publics</strong> et leur instruction</h3>
   </div>
@@ -16,7 +16,7 @@
     <p>Pré-remplissez les formulaires des entreprises postulant à vos appels d’offre et récupérez leurs justificatifs.</p>
   </div>
 </a>
-<a href="{{ site.baseurl }}{% link _use_cases/aides_publiques.md %}" class="tpl-card tpl-shadow">
+<a href="{{ site.baseurl }}{% link _use_cases/aides_publiques2.md %}" class="tpl-card tpl-shadow">
   <div class="tpl-card__header">
     <h3 class="tpl-card__title">Faciliter le dépôt et l’instruction des demandes d’<strong>aides publiques</strong></h3>
   </div>


### PR DESCRIPTION
Cette PR ré-affiche dans la page cas d'usages les nouveaux cas d'usages ainsi que la v2.

A noter que les versions 2 existent aussi sur gh-pages -> https://etalab.github.io/entreprise.api.gouv.fr/use_cases/marches_publics2/ et https://etalab.github.io/entreprise.api.gouv.fr/use_cases/aides_publiques2/

Les nouveaux cas d'usages (en local):

http://127.0.0.1:4000/entreprise.api.gouv.fr/use_cases/marches_publics2/
http://127.0.0.1:4000/entreprise.api.gouv.fr/use_cases/aides_publiques2/
http://127.0.0.1:4000/entreprise.api.gouv.fr/use_cases/preremplissage_public/
http://127.0.0.1:4000/entreprise.api.gouv.fr/use_cases/editeurs/
http://127.0.0.1:4000/entreprise.api.gouv.fr/use_cases/preremplissage_securise/
