### PR TITLE
Revue des urls endpoints

### DIFF
--- a/_catalogue/divers-documents-dune-association.md
+++ b/_catalogue/divers-documents-dune-association.md
@@ -39,7 +39,7 @@ services:
           label: object
           description: RaisonDeL’AppelOuIdentifiant
       url: |-
-        **documents_associations/**SiretDel'Association ou NumeroRNA
+        **documents_associations/**SiretDel'AssociationOuNuméroRNA
         **?token=**JetonD’Habilitation
         **&context=**CadreDeLaRequête
         **&recipient=**BénéficiaireDel’Appel

--- a/_catalogue/effectifs-dune-entreprise.md
+++ b/_catalogue/effectifs-dune-entreprise.md
@@ -154,9 +154,14 @@ services:
           }
       format: Donnée structurée JSON
       timeout: 5 secondes
-      description: La réponse JSON se compose de l'effectif du mois indiqué en
-        paramètre d'appel. La date ainsi que l'effectif de l'entreprise sont
-        indiqués pour un SIREN donné. L'effectif peut être un décimal.
+      description: >-
+        La réponse JSON se compose de l'effectif du mois indiqué en paramètre
+        d'appel. La date ainsi que l'effectif de l'entreprise sont indiqués pour
+        un SIREN donné. L'effectif peut être un décimal.\
+
+        \
+
+        Les effectifs étant mis à jour le 15 de chaque mois, avant cette date, il n'est possible de demander les effectifs que du mois précédent. Si la donnée est indisponible pour le mois demandé, l'API renverra un 404 avec un message d'erreur explicite.
   service3:
     request:
       id:
@@ -196,7 +201,11 @@ services:
           }
       format: Donnée structurée JSON
       timeout: 5 secondes
-      description: La réponse JSON se compose de l'effectif du mois indiqué en
-        paramètre d'appel. La date ainsi que l'effectif de l'établissement sont
-        indiqués pour un SIREN donné. L'effectif peut être un décimal.
+      description: >-
+        La réponse JSON se compose de l'effectif du mois indiqué en paramètre
+        d'appel. La date ainsi que l'effectif de l'établissement sont indiqués
+        pour un SIREN donné. L'effectif peut être un décimal.
+
+
+        Les effectifs étant mis à jour le 15 de chaque mois, avant cette date, il n'est possible de demander les effectifs que du mois précédent. Si la donnée est indisponible pour le mois demandé, l'API renverra un 404 avec un message d'erreur explicite.
 ---

--- a/_catalogue/informations-déclaratives-d’une-association.md
+++ b/_catalogue/informations-déclaratives-d’une-association.md
@@ -54,7 +54,7 @@ services:
           description: ""
           comment: ""
       url: |-
-        **associations/**SIRETdeL'AssociationOuNumeroRNA
+        **associations/**SIRETdeL'AssociationOuNuméroRNA
         **?token=**JetonD’Habilitation
         **&context=**CadreDeLaRequête
         **&recipient=**BénéficiaireDeL'appel


### PR DESCRIPTION
#### Que fait cette PR ?
C'est une relecture comparative de toutes les URLS d'appel des endpoints par rapport à l'ancienne documentation disponible ici : https://github.com/etalab/doc.entreprise.api.gouv.fr/tree/master/source/includes


#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?
Pour être sûr de ne pas avoir laissé des erreurs, car nous avons pas mal transformé la façon d'inscrire l'URL d'appel.

