### PR TITLE
Composant reccueil des besoins dans le catalogue

### DIFF
--- a/_sass/catalogue.scss
+++ b/_sass/catalogue.scss
@@ -810,6 +810,19 @@
     }
   }
 
+  .include-typeform {
+    background-color: white;
+    padding: 1em;
+    margin: 1em;
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  }
+
+  .include-typeform-titre {
+    text-decoration: underline;
+    margin-bottom: 3px;
+  }
+
   @media (max-width: 800px) {
     .tpl-documentation__sidebar {
       // display: none;

--- a/pages/catalogue.html
+++ b/pages/catalogue.html
@@ -361,6 +361,7 @@ is_catalogue: true
           <p>
             Le <b>numéro de PACAGE</b> peut-il vous être utile ?
           </p>
+          <a class="tpl-button tpl-button--primary" href="https://startupdetat.typeform.com/to/bH4QO4dc">Donner son avis<br>sur le numéro de PACAGE</a>
         </div>
       </nav>
     </aside>

--- a/pages/catalogue.html
+++ b/pages/catalogue.html
@@ -357,7 +357,7 @@ is_catalogue: true
         {% include catalogue_categories.html %}
         <a class="tpl-button tpl-button--alternate" href="{{ site.baseurl }}/doc/#demande-habilitation">🔑 Demander un accès</a>
         <div class="include-typeform">
-          <h6 class="include-typeform-titre">Transmettez-nous vos besoins</h6>
+          <h6 class="include-typeform-titre">Donnez-nous votre avis</h6>
           <p>
             Le <b>numéro de PACAGE</b> peut-il vous être utile ?
           </p>

--- a/pages/catalogue.html
+++ b/pages/catalogue.html
@@ -361,11 +361,6 @@ is_catalogue: true
           <p>
             Le <b>numéro de PACAGE</b> peut-il vous être utile ?
           </p>
-          <a class="typeform-share button" href="https://form.typeform.com/to/bH4QO4dc?typeform-medium=embed-snippet" 
-          data-mode="popup" 
-          style="display:inherit;text-decoration:none;background-color:#0048B3;color:white;cursor:pointer;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:40px;text-align:center;margin:0;height:40px;padding:0px 26px;border-radius:20px;max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:bold;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;" data-size="70" target="_blank">
-          Donner son avis</a> 
-          <script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script>
         </div>
       </nav>
     </aside>

--- a/pages/catalogue.html
+++ b/pages/catalogue.html
@@ -356,6 +356,17 @@ is_catalogue: true
       <nav class="tpl-documentation__links">
         {% include catalogue_categories.html %}
         <a class="tpl-button tpl-button--alternate" href="{{ site.baseurl }}/doc/#demande-habilitation">🔑 Demander un accès</a>
+        <div class="include-typeform">
+          <h6 class="include-typeform-titre">Transmettez-nous vos besoins</h6>
+          <p>
+            Le <b>numéro de PACAGE</b> peut-il vous être utile ?
+          </p>
+          <a class="typeform-share button" href="https://form.typeform.com/to/bH4QO4dc?typeform-medium=embed-snippet" 
+          data-mode="popup" 
+          style="display:inherit;text-decoration:none;background-color:#0048B3;color:white;cursor:pointer;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:40px;text-align:center;margin:0;height:40px;padding:0px 26px;border-radius:20px;max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:bold;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;" data-size="70" target="_blank">
+          Donner son avis</a> 
+          <script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script>
+        </div>
       </nav>
     </aside>
   </div>


### PR DESCRIPTION

#### Que fait cette PR ?
Ajout d'un composant dans la sidebar du catalogue pour reccueillir les besoins des utilisateurs en termes de données.

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?
Parce que l'on a régulièrement besoin d'avoir l'avis des utilisateurs et que le site peut être un relais pour mettre à disposition nos formulaires.
Ce premier composant est un test rapide pour voir si les utilisateurs s'emparent de cette fonctionnalité.

<img width="328" alt="Capture d’écran 2021-04-06 à 13 34 31" src="https://user-images.githubusercontent.com/46896006/113704743-d8d8f200-96dc-11eb-83ab-cb6a9fe25af6.png">
