### PR TITLE
Doc: Banque de France

### DIFF
--- a/_catalogue/bilans-annuels-3-dernières-années.md
+++ b/_catalogue/bilans-annuels-3-dernières-années.md
@@ -11,7 +11,8 @@ scope:
 description: "Obtenir les trois derniers bilans d’une entreprise détenus par la
   Banque de France. Ces bilans permettent d'accéder à **certaines informations
   contenues dans la liasse fiscale** : bilans, compte de résultat et annexes
-  confondus."
+  confondus. Ces données proviennent de la base **FIBEN (Fichier bancaire des
+  entreprises)** - hors cotation."
 usecases:
   - Détection de la fraude
 opening: Données protégées.


### PR DESCRIPTION
La documentation ne cite pas la source de la donnée Banque de France, qui est la base FIBEN (excepté les cotations). Cela peut aider les usagers à savoir de quoi on parle. Notamment lorsqu'il s'agit de trouver le cadre juridique qui leur permet d'accéder aux données.