### PR TITLE
Fin du support Java 1.7

### DIFF
--- a/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
+++ b/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
@@ -195,7 +195,7 @@ panels:
       ✅ Anticiper la mise à jour du logiciel métier ;
 
 
-      ✅ Avoir une version de langage suffisamment récente. API Entreprise ne fonctionne qu’avec Java 1.8 minimum (pour la gestion des certificats de +1024 bit, du TLS 1.2 minimum et des suite cryptographique - ciphers) ;
+      ✅ Avoir une version de langage suffisamment récente. API Entreprise ne fonctionne qu’avec Java 1.8 minimum (pour la gestion des certificats de +1024 bit, du TLS 1.2 minimum et des suites cryptographiques - ciphers) ;
 
 
       ✅ Prévoir de whitelister l'adresse IP du service API Entreprise si votre réseau est derrière un pare-feu. En effet, l'API Entreprise est accessible depuis internet.

--- a/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
+++ b/_documentation/les-prérequis-techniques-avant-d’aller-plus-loin.md
@@ -195,7 +195,7 @@ panels:
       ✅ Anticiper la mise à jour du logiciel métier ;
 
 
-      ✅ Avoir une version de langage suffisamment récente. API Entreprise ne fonctionne qu’avec Java 1.7 minimum (pour la gestion des certificats de +1024 bit) ;
+      ✅ Avoir une version de langage suffisamment récente. API Entreprise ne fonctionne qu’avec Java 1.8 minimum (pour la gestion des certificats de +1024 bit, du TLS 1.2 minimum et des suite cryptographique - ciphers) ;
 
 
       ✅ Prévoir de whitelister l'adresse IP du service API Entreprise si votre réseau est derrière un pare-feu. En effet, l'API Entreprise est accessible depuis internet.


### PR DESCRIPTION
Java 1.7 n'est plus supporté par API Entreprise : 
- il faut du TLS 1.2 (ok Java 1.7)
- en TLS 1.2/1.3 nous avons réduit la liste des ciphers autorisés