### PR TITLE
Ajout contenu doc page infolettre

### DIFF
--- a/_documentation/demander-une-information.md
+++ b/_documentation/demander-une-information.md
@@ -31,7 +31,7 @@ panels:
 
 
       <br>
-      **Vous souhaitez vous abonner à nos différentes lettres d'informations ?** Une [page dédiée](../infolettres/) vous permet de vous abonner aux infolettres 📮, aux techlettres ⚙️ et aux notifications de maintenance et d'incidents 🚧.
+      **Vous souhaitez vous abonner à nos différentes lettres d'informations ?** Une [page dédiée](../infolettres/) vous permet de vous abonner aux infolettres, aux techlettres et aux notifications de maintenance et d'incidents.
 
       Cette page vous permet également de consulter les archives des communications envoyées par API Entreprise.
 

--- a/_documentation/demander-une-information.md
+++ b/_documentation/demander-une-information.md
@@ -18,7 +18,7 @@ panels:
     content: >-
       API Entreprise rédige régulièrement des lettres d'information faisant état des
       dernières évolutions. Après validation de vos accès à l'API Entreprise, vous
-      êtes automatiquement abonnés à ces lettres d'information selon votre statut&nbsp;:
+      êtes automatiquement abonné à ces lettres d'information selon votre statut&nbsp;:
 
       * le demandeur et le contact métier reçoivent les infolettres 📮 ;
       
@@ -27,7 +27,7 @@ panels:
 
       {:.tpl-notification}
 
-      **Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos infolettres, il se peut qu'elle soit dans vos spams**. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
+      **Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos lettres d'information, il se peut qu'elle soit dans vos spams**. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
 
 
       <br>

--- a/_documentation/demander-une-information.md
+++ b/_documentation/demander-une-information.md
@@ -27,7 +27,7 @@ panels:
 
       {:.tpl-notification}
 
-      **Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos lettres d'information, il se peut qu'elle soit dans vos spams**. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
+      **Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos lettres d'information, il se peut qu'elles soient dans vos spams**. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
 
 
       <br>

--- a/_documentation/demander-une-information.md
+++ b/_documentation/demander-une-information.md
@@ -13,15 +13,28 @@ panels:
       Nous avons une page de support dédiée à l'adresse suivante:
       [Support](../support)
   panel2:
-    title: Infolettre API Entreprise 📬
+    title: Lettres d'information et notifications API Entreprise 📬
     id: infolettre
     content: >-
-      API Entreprise rédige régulièrement une infolettre faisant état des
-      dernières évolutions. Lors de votre inscription à API Entreprise, vous
-      êtes automatiquement abonnés à notre infolettre.
+      API Entreprise rédige régulièrement des lettres d'information faisant état des
+      dernières évolutions. Après validation de vos accès à l'API Entreprise, vous
+      êtes automatiquement abonnés à ces lettres d'information selon votre statut&nbsp;:
+
+      * le demandeur et le contact métier reçoivent les infolettres 📮 ;
+      
+      * le contact technique reçoit les techlettres ⚙️, et les notifications de maintenance et d'incidents 🚧. En cas d'incidents majeurs, les contacts métier et demandeur sont informés. 
 
 
       {:.tpl-notification}
 
-      Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos infolettres, il se peut qu'elle soit dans vos spams. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
+      **Si vous n'avez pas demandé expressement de vous désabonner, et que vous ne recevez pas nos infolettres, il se peut qu'elle soit dans vos spams**. Autrement, écrivez-nous à [support@entreprise.api.gouv.fr](<mailto:support@entreprise.api.gouv.fr?subject=Non reception de l'infolettre API Entreprise>)
+
+
+      <br>
+      **Vous souhaitez vous abonner à nos différentes lettres d'informations ?** Une [page dédiée](../infolettres/) vous permet de vous abonner aux infolettres 📮, aux techlettres ⚙️ et aux notifications de maintenance et d'incidents 🚧.
+
+      Cette page vous permet également de consulter les archives des communications envoyées par API Entreprise.
+
+
+
 ---

--- a/_documentation/demander-une-information.md
+++ b/_documentation/demander-une-information.md
@@ -36,5 +36,9 @@ panels:
       Cette page vous permet également de consulter les archives des communications envoyées par API Entreprise.
 
 
+      <a class="tpl-button tpl-button--primary" href="../infolettres/">S'abonner aux lettres d'informations</a>
+
+
+
 
 ---


### PR DESCRIPTION
#### Que fait cette PR ?
Elle met à jour le contenu du volet infolettre de la documentation

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?
Parce que depuis plusieurs semaines, les utilisateurs peuvent s'abonner aux différentes lettres d'informations depuis une page dédiée.
Ce n'était pas précisée dans l'ancienne doc qui sous-entendait qu'on ne pouvait pas s'abonner sans avoir été habilité.
