### PR TITLE
Ajout des liens vers la nouvelle status page

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -17,6 +17,9 @@
     -
       label: Lettre d'information
       target: pages/infolettres.html
+    -
+      label: Page de statut
+      url: https://status.entreprise.api.gouv.fr/
 -
   label: Tableau de bord
   url: https://dashboard.entreprise.api.gouv.fr

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -410,8 +410,10 @@ panels:
       peut que ce soit dû à un incident côté fournisseurs de données.
 
 
-      1. Dans une telle situation, **la première chose à faire est de consulter la [page incident](https://dashboard.entreprise.api.gouv.fr/incidents){:target="_blank"}** et de vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une indisponibilité pour maintenance.\
+      1. Dans une telle situation, **la première chose à faire est de consulter la [*status page* d'API Entreprise](https://api-entreprise.instatus.com/){:target="_blank"}** et vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une opération de maintenance.
+      <br><br>
          Vous pouvez **également consulter la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time){:target="_blank"}** et ainsi vérifier si l'endpoint ne fonctionnant pas est indiqué comme DOWN dans l'interface. API Entreprise a effectivement mis en place un système de test permettant de vérifier l'état de disponibilité de tous les endpoints.
+         <br><br>
       2. Si l'incident n'est pas répertorié, deux options se présentent : l'erreur provient de votre côté, ou bien elle n'a pas encore été identifiée par API Entreprise. Après avoir pris soin de regarder qu'il ne s'agit pas de la première option, vous pouvez nous contacter sur [support@entreprise.api.gouv.fr](mailto:support@entreprise.api.gouv.fr).
   panel7:
     title: Réagir en cas d’indisponibilité globale 🚧
@@ -425,8 +427,9 @@ panels:
 
       #### Agir en cas d'indisponibilité globale avérée
 
-
-      🚧 Ce contenu est en cours de construction et sera bientôt disponible. 🚧
+      En cas d'indisponibilité globale, l'ensemble des **endpoints seront indiqués comme DOWN dans l'interface de la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time){:target="_blank"}**. 
+      <br> <br>
+      L'**état et les informations de l'incident seront disponibles dans la [*status page*](https://api-entreprise.instatus.com/){:target="_blank"}**, mise à jour manuellement par API Entreprise. Vous y trouverez les informations les plus fraiches.    
   panel8:
     title: Élargir le périmètre des données demandées 🧩
     id: elargissement-perimetre

--- a/_documentation/api-entreprise-au-quotidien.md
+++ b/_documentation/api-entreprise-au-quotidien.md
@@ -410,7 +410,7 @@ panels:
       peut que ce soit dû à un incident côté fournisseurs de données.
 
 
-      1. Dans une telle situation, **la première chose à faire est de consulter la [*status page* d'API Entreprise](https://api-entreprise.instatus.com/){:target="_blank"}** et vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une opération de maintenance.
+      1. Dans une telle situation, **la première chose à faire est de consulter la [*status page* d'API Entreprise](https://status.entreprise.api.gouv.fr/){:target="_blank"}** et vérifier si l'indisponibilité n'y est pas répertoriée. Toutes les indisponibilités y sont inscrites dans le délai le plus court possible et parfois même anticipées lorsque le fournisseur de donnée nous prévient à l'avance d'une opération de maintenance.
       <br><br>
          Vous pouvez **également consulter la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time){:target="_blank"}** et ainsi vérifier si l'endpoint ne fonctionnant pas est indiqué comme DOWN dans l'interface. API Entreprise a effectivement mis en place un système de test permettant de vérifier l'état de disponibilité de tous les endpoints.
          <br><br>
@@ -427,9 +427,9 @@ panels:
 
       #### Agir en cas d'indisponibilité globale avérée
 
-      En cas d'indisponibilité globale, l'ensemble des **endpoints seront indiqués comme DOWN dans l'interface de la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time){:target="_blank"}**. 
+      En cas d'indisponibilité globale, l'ensemble des **endpoints seront indiqués comme DOWN dans l'interface de la [page temps réel](https://dashboard.entreprise.api.gouv.fr/real_time){:target="_blank"}**.
       <br> <br>
-      L'**état et les informations de l'incident seront disponibles dans la [*status page*](https://api-entreprise.instatus.com/){:target="_blank"}**, mise à jour manuellement par API Entreprise. Vous y trouverez les informations les plus fraiches.    
+      L'**état et les informations de l'incident seront disponibles dans la [*status page*](https://status.entreprise.api.gouv.fr/){:target="_blank"}**, mise à jour manuellement par API Entreprise. Vous y trouverez les informations les plus fraiches.
   panel8:
     title: Élargir le périmètre des données demandées 🧩
     id: elargissement-perimetre

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,11 +47,17 @@
 
               <div class="dropdown-content">
                 {% for child in link.children %}
-                  {% assign target = site.pages | where:"path",child.target | first %}
+                  {% if child.target %}
+                    {% assign target = site.pages | where:"path",child.target | first %}
 
-                  <a href="{{ site.baseurl }}{{ target.url }}">
-                    {{ child.label }}
-                  </a>
+                    <a href="{{ site.baseurl }}{{ target.url }}">
+                      {{ child.label }}
+                    </a>
+                  {% elsif child.url %}
+                    <a href="{{ child.url }}">
+                      {{ child.label }}
+                    </a>
+                  {% endif %}
                 {% endfor %}
               </div>
             </li>

--- a/_sass/newsletters.scss
+++ b/_sass/newsletters.scss
@@ -1,5 +1,6 @@
 .tpl-newsletters {
   .title-archives {
+    margin-top: 60px;
     margin-bottom: 60px;
   }
 

--- a/pages/infolettres.html
+++ b/pages/infolettres.html
@@ -22,6 +22,14 @@ class: newsletters
     <script type="text/javascript" src="https://app.mailjet.com/statics/js/iframeResizer.min.js"></script>
   </div>
 
+  <h2 class="tpl-text-center">
+    Incidents
+  </h2>
+
+  <p class="tpl-text-center">
+    🚧 Pour les incidents, vous pouvez vous abonner sur la page dédiée à l'adresse suivante: <a href="https://status.entreprise.api.gouv.fr/">Status page</a>
+  </p>
+
   <h2 class="tpl-text-center title-archives">
     Consulter les archives
   </h2>

--- a/pages/infolettres.html
+++ b/pages/infolettres.html
@@ -27,7 +27,7 @@ class: newsletters
   </h2>
 
   <p class="tpl-text-center">
-    🚧 Pour les incidents, vous pouvez vous abonner sur la page dédiée à l'adresse suivante: <a href="https://status.entreprise.api.gouv.fr/">Status page</a>
+    🚧 Pour être informé des incidents et opérations de maintenance, abonnez-vous aux endpoints qui vous intéressent, à la page dédiée suivante: <a href="https://status.entreprise.api.gouv.fr/">Status page</a>
   </p>
 
   <h2 class="tpl-text-center title-archives">


### PR DESCRIPTION
#### Que fait cette PR ?

Elle ajoute les liens vers la nouvelle page de status

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?

https://3.basecamp.com/4318089/buckets/21167830/todos/3755058578

------------------

Avant de merger / mettre en prod il faut retirer dans le module mailjet la checkbox Incidents.