### PR TITLE
Redirect to annuaire-entreprises on global search if there's a siren or siret

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,6 +25,8 @@ layout: default
       </div>
 
       <div id="hits" class="hidden">
+        <div id="hits-disclaimer">
+        </div>
         <div id="hits-catalogue-wrapper">
           <a class="category" href="{{ site.baseurl }}{% link pages/catalogue.html %}">
             <svg class="tpl-icon" viewBox="0 0 24 24">

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -195,15 +195,15 @@ function handleSiretSearch(query) {
   var str;
 
   if (sirenMatches || siretMatches) {
-    str = 'Il semblerait que vous essayez de rechercher des informations sur un siret ou siren spécifique, vous pouvez effectuer cette recherche sur le site <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">https://annuaire-entreprises.data.gouv.fr/</a>.';
+    str = 'Il semblerait que vous essayez de rechercher des informations sur un SIRET ou SIREN spécifique, vous pouvez effectuer cette recherche sur le site <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">https://annuaire-entreprises.data.gouv.fr/</a>.';
   }
 
   if (siretMatches) {
     str += '<br /><br />';
-    str += 'Vous pouvez obtenir les informations du siret '+siretMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/'+siretMatches[0]+'" target="_blank">ce lien</a>.';
+    str += 'Vous pouvez obtenir les informations du SIRET '+siretMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/'+siretMatches[0]+'" target="_blank">ce lien</a>.';
   } else if (sirenMatches) {
     str += '<br /><br />';
-    str += 'Vous pouvez obtenir les informations du siren '+sirenMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/entreprise/'+sirenMatches[0]+'" target="_blank">ce lien</a>.';
+    str += 'Vous pouvez obtenir les informations du SIREN '+sirenMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/entreprise/'+sirenMatches[0]+'" target="_blank">ce lien</a>.';
   }
 
   if (sirenMatches || siretMatches) {

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -51,7 +51,8 @@ function setupHomeSearch() {
       container: '#hits-documentation',
       escapeHTML: false,
       templates: {
-        empty() {
+        empty(results) {
+          handleSiretSearch(results.query);
           return 'Aucun résultat';
         },
         item(result) {
@@ -182,4 +183,30 @@ function setupHomeSearch() {
   );
 
   search.start();
+}
+
+function handleSiretSearch(query) {
+  var sirenRegex = /\d{9}/;
+  var siretRegex = /\d{14}/;
+
+  var sanitizedQuery = query.replace(/\s/g, '');
+  var sirenMatches = sanitizedQuery.match(sirenRegex);
+  var siretMatches = sanitizedQuery.match(siretRegex);
+  var str;
+
+  if (sirenMatches) {
+    str = 'Il semblerait que vous essayez de rechercher des informations sur un siret ou siren spécifique, vous pouvez effectuer cette recherche sur le site <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">https://annuaire-entreprises.data.gouv.fr/</a>.';
+
+    if (siretMatches) {
+      str += '<br /><br />';
+      str += 'Vous pouvez obtenir les informations du siret '+siretMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/'+siretMatches[0]+'" target="_blank">ce lien</a>.';
+    }
+
+    str += '<br /><br />';
+  }
+  else {
+    str = '';
+  }
+
+  document.getElementById('hits-disclaimer').innerHTML = str;
 }

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -194,14 +194,19 @@ function handleSiretSearch(query) {
   var siretMatches = sanitizedQuery.match(siretRegex);
   var str;
 
-  if (sirenMatches) {
+  if (sirenMatches || siretMatches) {
     str = 'Il semblerait que vous essayez de rechercher des informations sur un siret ou siren spécifique, vous pouvez effectuer cette recherche sur le site <a href="https://annuaire-entreprises.data.gouv.fr/" target="_blank">https://annuaire-entreprises.data.gouv.fr/</a>.';
+  }
 
-    if (siretMatches) {
-      str += '<br /><br />';
-      str += 'Vous pouvez obtenir les informations du siret '+siretMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/'+siretMatches[0]+'" target="_blank">ce lien</a>.';
-    }
+  if (siretMatches) {
+    str += '<br /><br />';
+    str += 'Vous pouvez obtenir les informations du siret '+siretMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/'+siretMatches[0]+'" target="_blank">ce lien</a>.';
+  } else if (sirenMatches) {
+    str += '<br /><br />';
+    str += 'Vous pouvez obtenir les informations du siren '+sirenMatches[0]+' en suivant <a href="https://annuaire-entreprises.data.gouv.fr/entreprise/'+sirenMatches[0]+'" target="_blank">ce lien</a>.';
+  }
 
+  if (sirenMatches || siretMatches) {
     str += '<br /><br />';
   }
   else {


### PR DESCRIPTION
#### Que fait cette PR ?

Quand on utilisateur utilise la recherche globale avec un siren ou siret, un disclaimer s'affiche vers annuaire-entreprises

#### Pourquoi fait-on ça ? Contexte, PR, issue liée ?

https://3.basecamp.com/4318089/buckets/14906626/todos/3661289116