### PR TITLE
Mise à jour option de pandoc

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,7 +55,7 @@ end
 
 task :cgu_to_pdf do
   comment 'Generating PDF version of CGU'.green
-  command %(pandoc pages/cgu.md -o _site/assets/cgu.pdf --latex-engine=xelatex)
+  command %(pandoc pages/cgu.md -o _site/assets/cgu.pdf --pdf-engine=xelatex)
 end
 
 task :algolia_indexing do


### PR DESCRIPTION
Sur Ubuntu 20.04, la version de pandoc plus récente refuse l'option `--latex-engine` avec le message d'erreur suivant, ce qui fait échouer le déploiement :

    --latex-engine has been removed.  Use --pdf-engine instead.

Cela fonctionne avec le changement de cette PR.